### PR TITLE
fix Moment.Calender Display bug

### DIFF
--- a/MomentSharp.Tests/Parse.cs
+++ b/MomentSharp.Tests/Parse.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Threading;
+using System.Globalization;
 
 namespace MomentSharp.Tests
 {
@@ -19,6 +21,22 @@ namespace MomentSharp.Tests
         public void ToUTC()
         {
             //Eastern Standard Time
+        }
+
+        [TestMethod]
+        public void CalendarTest()
+        {
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("zh-CN");
+            var m = new Moment(); 
+            var str = m.Calendar();
+            Assert.AreEqual(str.IndexOf("今天"), 0, "should be Today");
+
+            var str2 = m.Calendar(DateTime.Now.AddDays(-1)); 
+            Assert.AreEqual(str2.IndexOf("明天"), 0, "should be Tomorrow");
+
+            var str3 = m.Calendar(DateTime.Now.AddDays(1));
+            Assert.AreEqual(str3.IndexOf("昨天"), 0, "should be Yesterday");
+
         }
     }
 }

--- a/MomentSharp/Display.cs
+++ b/MomentSharp/Display.cs
@@ -85,15 +85,16 @@ namespace MomentSharp
             var local = moment.Language;
             if (dateTime == default(DateTime)) dateTime = DateTime.Now;
 
-            var timeSpan = (moment.DateTime() - dateTime).TotalDays;
+            //compare width DateTimeParts.Day
+            var timeSpan = (moment.DateTime() - dateTime.StartOf(DateTimeParts.Day)).TotalDays;
 
-            if (timeSpan < -6) return local.Translate(Globalization.Calendar.SameElse, moment.DateTime());
-            if (timeSpan < -1) return local.Translate(Globalization.Calendar.LastWeek, dateTime);
-            if (timeSpan < 0) return local.Translate(Globalization.Calendar.LastDay, dateTime);
-            if (timeSpan < 1) return local.Translate(Globalization.Calendar.SameDay, dateTime);
-            if (timeSpan < 2) return local.Translate(Globalization.Calendar.NextDay, dateTime);
-            if (timeSpan < 7) return local.Translate(Globalization.Calendar.NextWeek, dateTime);
-            return local.Translate(Globalization.Calendar.SameElse, moment.DateTime());
+            if (timeSpan < -6) return local.Translate(Globalization.Calendar.SameElse, moment.LocalTime());
+            if (timeSpan < -1) return local.Translate(Globalization.Calendar.LastWeek, moment.LocalTime());
+            if (timeSpan < 0) return local.Translate(Globalization.Calendar.LastDay, moment.LocalTime());
+            if (timeSpan < 1) return local.Translate(Globalization.Calendar.SameDay, moment.LocalTime());
+            if (timeSpan < 2) return local.Translate(Globalization.Calendar.NextDay, moment.LocalTime());
+            if (timeSpan < 7) return local.Translate(Globalization.Calendar.NextWeek, moment.LocalTime());
+            return local.Translate(Globalization.Calendar.SameElse, moment.LocalTime());
         }
 
         /// <summary>

--- a/MomentSharp/Parse.cs
+++ b/MomentSharp/Parse.cs
@@ -55,6 +55,17 @@ namespace MomentSharp
         }
 
         /// <summary>
+        /// Convert this <paramref name="moment" /> object to LocalTime <see cref="System.DateTime" />
+        /// </summary>
+        /// <param name="moment">A Moment Object</param>
+        /// <returns>DateTime</returns>
+        public static DateTime LocalTime(this Moment moment)
+        {
+            var dateTime = moment.DateTime();
+            return dateTime.ToLocalTime();
+        }
+
+        /// <summary>
         ///     Converts this <paramref name="dateTime" /> to a <see cref="Moment" /> object
         /// </summary>
         /// <param name="dateTime">this DateTime</param>


### PR DESCRIPTION
1.compare with referenceTime  bug fixed

  `var timeSpan = (moment.DateTime() - dateTime.StartOf(DateTimeParts.Day)).TotalDays;`

2.Parse.cs add `LocalTime` method,and use `moment.LocalTime()` when translate to local language display
